### PR TITLE
Fix NuBuild bug that causes it to falsely report that verification succeeds

### DIFF
--- a/ironfleet/README.md
+++ b/ironfleet/README.md
@@ -71,7 +71,7 @@ You can still use NuBuild without cloud support, however, by passing the `--no-c
 
 To verify an individual Dafny file (and all of its dependencies), run:
 
-  `./bin_tools/NuBuild/NuBuild.exe --no-cloudcache -j 3 DafnyVerifyTree src/Dafny/Distributed/Protocol/SHT/AppInterface.i.dfy`
+  `./bin_tools/NuBuild/NuBuild.exe --no-cloudcache -j 3 DafnyVerifyTree src/Dafny/Distributed/Impl/SHT/AppInterface.i.dfy`
 
 which uses the `-j` flag to add 3-way local parallelism.
 
@@ -104,7 +104,7 @@ to do this is to comment out the body of the RecordTimingSeq method in
 To build the unverified C# clients for IronRSL and IronKV, open and build (in Release mode):
 
   `./src/IronfleetClient/IronfleetClient.sln`
-  `./src/IronfleetShtClient/IronfleetShtClient.sln`
+  `./src/IronKVClient/IronfleetClient.sln`
 
 # Running
 

--- a/ironfleet/tools/NuBuild/NuBuild/VerificationResultBoogieParser.cs
+++ b/ironfleet/tools/NuBuild/NuBuild/VerificationResultBoogieParser.cs
@@ -34,14 +34,6 @@ namespace NuBuild
                 return;
             }
 
-            match = dispositionNoTimeoutsRegex.Match(output);
-            if (match.Success)
-            {
-                ////int succeeding_methods = Int32.Parse(m.Groups[1].ToString());
-                verificationFailures = Int32.Parse(match.Groups[2].ToString());
-                return;
-            }
-
             match = dispositionParseErrorRegex.Match(output);
             if (match.Success)
             {
@@ -74,6 +66,14 @@ namespace NuBuild
             if (match.Success)
             {
                 parseFailures = 1;
+                return;
+            }
+
+            match = dispositionNoTimeoutsRegex.Match(output);
+            if (match.Success)
+            {
+                ////int succeeding_methods = Int32.Parse(m.Groups[1].ToString());
+                verificationFailures = Int32.Parse(match.Groups[2].ToString());
                 return;
             }
 

--- a/ironfleet/tools/NuBuild/NuBuild/VerificationResultDafnyParser.cs
+++ b/ironfleet/tools/NuBuild/NuBuild/VerificationResultDafnyParser.cs
@@ -33,14 +33,6 @@ namespace NuBuild
                 return;
             }
 
-            match = dispositionNoTimeoutsRegex.Match(output);
-            if (match.Success)
-            {
-                ////int succeeding_methods = Int32.Parse(m.Groups[1].ToString());
-                verificationFailures = Int32.Parse(match.Groups[2].ToString());
-                return;
-            }
-
             match = dispositionParseErrorRegex.Match(output);
             if (match.Success)
             {
@@ -66,6 +58,14 @@ namespace NuBuild
             if (match.Success)
             {
                 parseFailures = 1;
+                return;
+            }
+
+            match = dispositionNoTimeoutsRegex.Match(output);
+            if (match.Success)
+            {
+                ////int succeeding_methods = Int32.Parse(m.Groups[1].ToString());
+                verificationFailures = Int32.Parse(match.Groups[2].ToString());
                 return;
             }
 


### PR DESCRIPTION
These commits fix a bug that causes NuBuild to falsely report to the user that the verification checks validate when, for example, the checks fail because the prover dies. The bug is caused by the order used to match regular expressions against Dafny's output in ironfleet/tools/NuBuild/NuBuild/VerificationResultDafnyParser.cs. A similar problem exists for the code that parses Boogie's output in VerificationResultBoogieParser.cs.

This bug is triggered in the current ironfleet repository because of another problem -- the included z3.exe binary was built for 64-bit while the included dll's where built for 32-bit architectures. This architecture mismatch causes z3 to fail to execute. More importantly, this mismatch triggers the NuBuild bug.

The following commits fix the NuBuild _source code_ bug:
  f63fc765b8281cfefb83c3193f403d4ca4a894c7
  642512d56d29419932057c150936b9b9ecac36e1

The following commit fixes the z3.exe compatibility problem by reverting a commit made in October:
  5516eb515b1fcc78f4db9ba7d35dfff49cbebb35

In addition, the NuBuild binary included in the repository (/ironfleet/bin_tools/NuBuild/NuBuild.exe) should be updated. I presume that you would want someone from Microsoft to build the binary so I have not included a patch for this.
