### PR TITLE
Ensure compatibility with recent Dafny

### DIFF
--- a/ironfleet/src/Dafny/Distributed/Common/Collections/CountMatches.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Common/Collections/CountMatches.i.dfy
@@ -21,7 +21,7 @@ function CountMatchesInMultiset<T(!new)>(m:multiset<T>, f:T-->bool):int
     CountMatchesInMultiset(m - multiset{x}, f) + if f(x) then 1 else 0
 }
 
-lemma Lemma_RemovingElementAffectsCount<T>(m:multiset<T>, f:T-->bool, x:T)
+lemma Lemma_RemovingElementAffectsCount<T(!new)>(m:multiset<T>, f:T-->bool, x:T)
   requires forall u :: f.requires(u)
   requires x in m
   ensures  CountMatchesInMultiset(m, f) - CountMatchesInMultiset(m - multiset{x}, f) == if f(x) then 1 else 0
@@ -38,7 +38,7 @@ lemma Lemma_RemovingElementAffectsCount<T>(m:multiset<T>, f:T-->bool, x:T)
   }
 }
 
-lemma Lemma_MatchCountInSeqIsMatchCountInMultiset<T>(s:seq<T>, m:multiset<T>, f:T-->bool)
+lemma Lemma_MatchCountInSeqIsMatchCountInMultiset<T(!new)>(s:seq<T>, m:multiset<T>, f:T-->bool)
   requires forall x :: f.requires(x)
   requires m == multiset(s)
   ensures  CountMatchesInSeq(s, f) == CountMatchesInMultiset(m, f)

--- a/ironfleet/src/Dafny/Distributed/Common/Collections/Maps.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Common/Collections/Maps.i.dfy
@@ -25,7 +25,7 @@ function union<U(!new), V>(m: map<U,V>, m': map<U,V>): map<U,V>
   map i{:auto_trigger} | i in (domain(m) + domain(m')) :: if i in m then m[i] else m'[i]
 }
 
-function method RemoveElt<U(!new),V>(m:map<U,V>, elt:U) : map<U,V>
+function method RemoveElt<U(!new),V(!new)>(m:map<U,V>, elt:U) : map<U,V>
   requires elt in m
   decreases |m|
   ensures |RemoveElt(m, elt)| == |m| - 1
@@ -37,7 +37,7 @@ function method RemoveElt<U(!new),V>(m:map<U,V>, elt:U) : map<U,V>
   m'
 }
 
-lemma lemma_non_empty_map_has_elements<S,T>(m:map<S,T>)
+lemma lemma_non_empty_map_has_elements<S(!new),T(!new)>(m:map<S,T>)
   requires |m| > 0
   ensures exists x :: x in m
 {
@@ -48,7 +48,7 @@ lemma lemma_non_empty_map_has_elements<S,T>(m:map<S,T>)
   assert |dom| > 0;
 }
 
-lemma lemma_MapSizeIsDomainSize<S,T>(dom:set<S>, m:map<S,T>)
+lemma lemma_MapSizeIsDomainSize<S(!new),T(!new)>(dom:set<S>, m:map<S,T>)
   requires dom == domain(m)
   ensures |m| == |dom|
 {
@@ -69,7 +69,7 @@ lemma lemma_MapSizeIsDomainSize<S,T>(dom:set<S>, m:map<S,T>)
   }
 }
 
-lemma lemma_maps_decrease<S,T>(before:map<S,T>, after:map<S,T>, item_removed:S)
+lemma lemma_maps_decrease<S(!new),T(!new)>(before:map<S,T>, after:map<S,T>, item_removed:S)
   requires item_removed in before
   requires after == map s | s in before && s != item_removed :: before[s]
   ensures  |after| < |before|
@@ -123,7 +123,7 @@ lemma lemma_maps_decrease<S,T>(before:map<S,T>, after:map<S,T>, item_removed:S)
 }
 
 
-lemma lemma_map_remove_one<S,T>(before:map<S,T>, after:map<S,T>, item_removed:S)
+lemma lemma_map_remove_one<S(!new),T(!new)>(before:map<S,T>, after:map<S,T>, item_removed:S)
   requires item_removed in before
   requires after == map s | s in before && s != item_removed :: before[s]
   ensures  |after| + 1 == |before|

--- a/ironfleet/src/Dafny/Distributed/Common/Collections/Maps2.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Common/Collections/Maps2.i.dfy
@@ -11,7 +11,7 @@ function maprange<KT,VT>(m:map<KT,VT>) : set<VT>
 
 type imap2<K1, K2, V> = imap<K1, imap<K2, V>>
 
-predicate imap2total<K1(!new), K2, V>(m:imap2<K1, K2, V>)
+predicate imap2total<K1(!new), K2(!new), V>(m:imap2<K1, K2, V>)
 {
   imaptotal(m) && forall k1 :: imaptotal(m[k1])
 }

--- a/ironfleet/src/Dafny/Distributed/Common/Framework/EnvironmentSynchronyLemmas.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Common/Framework/EnvironmentSynchronyLemmas.i.dfy
@@ -79,7 +79,7 @@ predicate AllPacketsReceivedWithin<IdType(!new), MessageType(!new)>(
       sat(i, next(eventuallynextwithin(PacketReceivedTemporal(b, p), receive_period, BehaviorToTimeMap(b))))
 }
 
-function{:opaque} AllPacketsReceivedWithinTemporal<IdType, MessageType>(
+function{:opaque} AllPacketsReceivedWithinTemporal<IdType(!new), MessageType(!new)>(
   b:Behavior<LEnvironment<IdType, MessageType>>,
   receive_period:int,
   sources:set<IdType>,
@@ -946,7 +946,7 @@ lemma Lemma_EventuallyEachHostQueueEmpties<IdType, MessageType>(
   }
 }
 
-lemma Lemma_EventuallyAllPacketsAlwaysReceivedInTimeHelper3<IdType, MessageType>(
+lemma Lemma_EventuallyAllPacketsAlwaysReceivedInTimeHelper3<IdType(!new), MessageType(!new)>(
   synchrony_start:int,
   latency_bound:int,
   sources:set<IdType>,
@@ -1071,7 +1071,7 @@ lemma Lemma_EventuallyAllPacketsAlwaysReceivedInTimeHelper3<IdType, MessageType>
   processing_bound := latency_bound + burst_size * receive_period;
 }
 
-lemma Lemma_EventuallyAllPacketsAlwaysReceivedInTimeHelper2<IdType, MessageType>(
+lemma Lemma_EventuallyAllPacketsAlwaysReceivedInTimeHelper2<IdType(!new), MessageType(!new)>(
   synchrony_start:int,
   i1:int,
   latency_bound:int,
@@ -1127,7 +1127,7 @@ lemma Lemma_EventuallyAllPacketsAlwaysReceivedInTimeHelper2<IdType, MessageType>
   processing_sync_start := i1;
 }
 
-lemma Lemma_EventuallyAllPacketsAlwaysReceivedInTime<IdType, MessageType>(
+lemma Lemma_EventuallyAllPacketsAlwaysReceivedInTime<IdType(!new), MessageType(!new)>(
   synchrony_start:int,
   latency_bound:int,
   sources:set<IdType>,

--- a/ironfleet/src/Dafny/Distributed/Common/Framework/HostQueueLemmas.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Common/Framework/HostQueueLemmas.i.dfy
@@ -123,7 +123,7 @@ predicate HostQueueDecomposition<IdType, MessageType>(
   hostQueue == s1 + [p] + s2 + hostQueue'
 }
 
-lemma{:timeLimitMultiplier 2} Lemma_ReceiveRemovesPacketFromHostQueue<IdType, MessageType>(
+lemma Lemma_ReceiveRemovesPacketFromHostQueue<IdType, MessageType>(
   hostQueue:seq<LPacket<IdType, MessageType>>,
   hostQueue':seq<LPacket<IdType, MessageType>>,
   ios:seq<LIoOp<IdType, MessageType>>,
@@ -154,23 +154,21 @@ lemma{:timeLimitMultiplier 2} Lemma_ReceiveRemovesPacketFromHostQueue<IdType, Me
       [hostQueue[0]] + hostQueue[1..j+1] + hostQueue[1..][j..];
     }
     assert HostQueueDecomposition(hostQueue, hostQueue', s1, s2, p);
+    return;
   }
-  else
-  {
-    Lemma_IfOpSeqIsCompatibleWithReductionThenSoIsSuffix(ios, 1);
-    Lemma_ReceiveRemovesPacketFromHostQueue(hostQueue[1..], hostQueue', ios[1..], p);
-    var s1', s2 :| hostQueue[1..] == s1' + [p] + s2 + hostQueue';
-    var j := Lemma_HostQueuePerformIosProducesTail(hostQueue[1..], hostQueue', ios[1..]);
-    assert 0 <= j <= |hostQueue[1..]| && hostQueue' == hostQueue[1..][j..];
-    calc {
-      hostQueue;
-      [hostQueue[0]] + hostQueue[1..];
-      [hostQueue[0]] + s1' + [p] + s2 + hostQueue';
-    }
-    var s1 := [hostQueue[0]] + s1';
-    assert HostQueueDecomposition(hostQueue, hostQueue', s1, s2, p);
+
+  Lemma_IfOpSeqIsCompatibleWithReductionThenSoIsSuffix(ios, 1);
+  Lemma_ReceiveRemovesPacketFromHostQueue(hostQueue[1..], hostQueue', ios[1..], p);
+  var s1', s2 :| hostQueue[1..] == s1' + [p] + s2 + hostQueue';
+  var j := Lemma_HostQueuePerformIosProducesTail(hostQueue[1..], hostQueue', ios[1..]);
+  assert 0 <= j <= |hostQueue[1..]| && hostQueue' == hostQueue[1..][j..];
+  calc {
+    hostQueue;
+    [hostQueue[0]] + hostQueue[1..];
+    [hostQueue[0]] + s1' + [p] + s2 + hostQueue';
   }
-  assert exists s1, s2 :: HostQueueDecomposition(hostQueue, hostQueue', s1, s2, p);
+  var s1 := [hostQueue[0]] + s1';
+  assert HostQueueDecomposition(hostQueue, hostQueue', s1, s2, p);
 }
 
 lemma Lemma_RemovePacketFromHostQueueImpliesReceive<IdType, MessageType>(

--- a/ironfleet/src/Dafny/Distributed/Common/Native/Io.s.dfy
+++ b/ironfleet/src/Dafny/Distributed/Common/Native/Io.s.dfy
@@ -13,6 +13,8 @@ class HostEnvironment
   ghost var udp:UdpState;
   ghost var files:FileSystemState;
 
+  constructor{:axiom} () requires false
+
   predicate Valid()
     reads this
   {

--- a/ironfleet/src/Dafny/Distributed/Impl/Common/GenericRefinement.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Impl/Common/GenericRefinement.i.dfy
@@ -134,8 +134,8 @@ lemma Lemma_AbstractifyMap_append<KT,VT,CKT,CVT>(cm:map<CKT,CVT>, RefineKey:CKT~
   assert r_cm' == rm';
 }
 
-lemma Lemma_AbstractifyMap_remove<KT,VT,CKT,CVT>(cm:map<CKT,CVT>, RefineKey:CKT~>KT, RefineValue:CVT~>VT, ReverseKey:KT~>CKT,
-                                                 ck:CKT)
+lemma Lemma_AbstractifyMap_remove<KT(!new),VT(!new),CKT(!new),CVT(!new)>(
+  cm:map<CKT,CVT>, RefineKey:CKT~>KT, RefineValue:CVT~>VT, ReverseKey:KT~>CKT, ck:CKT)
   requires MapIsAbstractable(cm, RefineKey, RefineValue, ReverseKey)
   // Injectivity
   requires forall ck1, ck2 :: RefineKey.requires(ck1) && RefineKey.requires(ck2) && RefineKey(ck1) == RefineKey(ck2) ==> ck1 == ck2
@@ -179,7 +179,8 @@ lemma Lemma_AbstractifyMap_remove<KT,VT,CKT,CVT>(cm:map<CKT,CVT>, RefineKey:CKT~
   assert rm' == smaller_rm;
 }
 
-lemma lemma_AbstractifyMap_properties<CKT,CVT,KT,VT>(cm:map<CKT,CVT>, RefineKey:CKT~>KT, RefineValue:CVT~>VT, ReverseKey:KT~>CKT)
+lemma lemma_AbstractifyMap_properties<CKT(!new),CVT(!new),KT(!new),VT(!new)>(
+  cm:map<CKT,CVT>, RefineKey:CKT~>KT, RefineValue:CVT~>VT, ReverseKey:KT~>CKT)
   requires MapIsAbstractable(cm, RefineKey, RefineValue, ReverseKey)
   // Injectivity
   requires forall ck1, ck2 :: RefineKey.requires(ck1) && RefineKey.requires(ck2) && RefineKey(ck1) == RefineKey(ck2) ==> ck1 == ck2

--- a/ironfleet/src/Dafny/Distributed/Impl/RSL/ProposerModel.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Impl/RSL/ProposerModel.i.dfy
@@ -303,7 +303,7 @@ method ProposerProcess1b(proposer:ProposerState, packet:CPacket) returns (propos
   lemma_AbstractifySetOfCPacketsToSetOfRslPackets_srcMembership(proposer.received_1b_packets, packet.src);
 }
 
-lemma lemma_MapSingleton<T,S>(m:map<T,S>, elm:T)
+lemma lemma_MapSingleton<T(!new),S(!new)>(m:map<T,S>, elm:T)
   requires |m| == 1
   requires elm in m
   ensures forall x :: x in m ==> x == elm

--- a/ironfleet/src/Dafny/Distributed/Impl/RSL/ReplicaImplReadClock.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Impl/RSL/ReplicaImplReadClock.i.dfy
@@ -79,6 +79,17 @@ lemma lemma_ReplicaNextReadClockAndProcessPacketHelper(
     var i :| 0 <= i < |send_ios| && io == send_ios[i];  // OBSERVE trigger
   }
   assert AbstractifyRawLogToIos(all_events) == all_ios;
+
+  calc {
+    final_history;
+    pre_delivery_history + send_events;
+    pre_clock_history + [clock_event] + send_events;
+    old_history + [receive_event] + [clock_event] + send_events;
+    old_history + ([receive_event] + [clock_event]) + send_events;
+    old_history + [receive_event, clock_event] + send_events;
+    old_history + ([receive_event, clock_event] + send_events);
+    old_history + all_events;
+  }
 }
 
 method {:fuel ReplicaStateIsValid,0,0} {:timeLimitMultiplier 3} Replica_Next_ReadClockAndProcessPacket(

--- a/ironfleet/src/Dafny/Distributed/Impl/SHT/Delegations.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Impl/SHT/Delegations.i.dfy
@@ -593,8 +593,10 @@ lemma {:timeLimitMultiplier 4} UpdateCDelegationMap_RHS(m:CDelegationMap, newkr:
     assert AbstractifyCDelegationMapToDelegationMap(m')[k] == UpdateDelegationMap(AbstractifyCDelegationMapToDelegationMap(m), newkr, AbstractifyEndPointToNodeIdentity(id))[k];
 }
 
-lemma UpdateCDelegationMap_Part1(m:CDelegationMap, newkr:KeyRange, id:EndPoint, m':CDelegationMap,
-                                 left_index:int, right_index:int, new_left:seq<Mapping>, new_right:seq<Mapping>)
+lemma {:timeLimitMultiplier 2} UpdateCDelegationMap_Part1(
+    m:CDelegationMap, newkr:KeyRange, id:EndPoint, m':CDelegationMap,
+    left_index:int, right_index:int, new_left:seq<Mapping>, new_right:seq<Mapping>
+    )
     requires CDelegationMapIsValid(m);
     requires EndPointIsValidIPV4(id);
     requires !EmptyKeyRange(newkr);


### PR DESCRIPTION
The recent main version of Dafny, at commit 0ae4fc725f44520a544658320f27787b3f28c679, raises some new errors when verifying Ironfleet files. This change makes both Dafny 3.0.0 and that recent commit able to verify Ironfleet.
