### PR TITLE
Add colon notation and DNS lookups for command-line arguments

### DIFF
--- a/ironfleet/README.md
+++ b/ironfleet/README.md
@@ -88,9 +88,9 @@ you need to supply each process with the IP-port pairs of all processes, as well
 as its own IP-pair. For example, this is a configuration with three processes:
 
 ```
-  dotnet src/Dafny/Distributed/Services/Lock/build/IronfleetShell.dll 127.0.0.1 4001 127.0.0.1 4002 127.0.0.1 4003 127.0.0.1 4002
-  dotnet src/Dafny/Distributed/Services/Lock/build/IronfleetShell.dll 127.0.0.1 4001 127.0.0.1 4002 127.0.0.1 4003 127.0.0.1 4003
-  dotnet src/Dafny/Distributed/Services/Lock/build/IronfleetShell.dll 127.0.0.1 4001 127.0.0.1 4002 127.0.0.1 4003 127.0.0.1 4001
+  dotnet src/Dafny/Distributed/Services/Lock/build/IronfleetShell.dll localhost:4001 localhost:4002 localhost:4003 localhost:4002
+  dotnet src/Dafny/Distributed/Services/Lock/build/IronfleetShell.dll localhost:4001 localhost:4002 localhost:4003 localhost:4003
+  dotnet src/Dafny/Distributed/Services/Lock/build/IronfleetShell.dll localhost:4001 localhost:4002 localhost:4003 localhost:4001
 ```
 
 It's important that you start the "first" process last (as in the above
@@ -118,9 +118,9 @@ For example, to test IronRSL on a single machine, you can run each of the
 following four commands in a different console:
 
 ```
-  dotnet src/Dafny/Distributed/Services/RSL/build/IronfleetShell.dll 127.0.0.1 4001 127.0.0.1 4002 127.0.0.1 4003 127.0.0.1 4001
-  dotnet src/Dafny/Distributed/Services/RSL/build/IronfleetShell.dll 127.0.0.1 4001 127.0.0.1 4002 127.0.0.1 4003 127.0.0.1 4002
-  dotnet src/Dafny/Distributed/Services/RSL/build/IronfleetShell.dll 127.0.0.1 4001 127.0.0.1 4002 127.0.0.1 4003 127.0.0.1 4003
+  dotnet src/Dafny/Distributed/Services/RSL/build/IronfleetShell.dll localhost:4001 localhost:4002 localhost:4003 localhost:4001
+  dotnet src/Dafny/Distributed/Services/RSL/build/IronfleetShell.dll localhost:4001 localhost:4002 localhost:4003 localhost:4002
+  dotnet src/Dafny/Distributed/Services/RSL/build/IronfleetShell.dll localhost:4001 localhost:4002 localhost:4003 localhost:4003
   dotnet src/IronRSLClient/bin/Release/net5.0/IronRSLClient.dll nthreads=10 duration=30 clientport=6000 initialseqno=0
 ```
 
@@ -148,9 +148,9 @@ takes command-line arguments of the form key=value.
 For example, you can run each of the following four commands in a different
 console:
 ```
-  dotnet src/Dafny/Distributed/Services/SHT/build/IronfleetShell.dll 127.0.0.1 4001 127.0.0.1 4002 127.0.0.1 4003 127.0.0.1 4001
-  dotnet src/Dafny/Distributed/Services/SHT/build/IronfleetShell.dll 127.0.0.1 4001 127.0.0.1 4002 127.0.0.1 4003 127.0.0.1 4002
-  dotnet src/Dafny/Distributed/Services/SHT/build/IronfleetShell.dll 127.0.0.1 4001 127.0.0.1 4002 127.0.0.1 4003 127.0.0.1 4003
+  dotnet src/Dafny/Distributed/Services/SHT/build/IronfleetShell.dll localhost:4001 localhost:4002 localhost:4003 localhost:4001
+  dotnet src/Dafny/Distributed/Services/SHT/build/IronfleetShell.dll localhost:4001 localhost:4002 localhost:4003 localhost:4002
+  dotnet src/Dafny/Distributed/Services/SHT/build/IronfleetShell.dll localhost:4001 localhost:4002 localhost:4003 localhost:4003
   dotnet src/IronKVClient/bin/Release/net5.0/IronKVClient.dll nthreads=10 duration=30 workload=g numkeys=10000 clientport=6000
 ```
 

--- a/ironfleet/src/Dafny/Distributed/Common/Framework/Host.s.dfy
+++ b/ironfleet/src/Dafny/Distributed/Common/Framework/Host.s.dfy
@@ -20,6 +20,8 @@ predicate HostStateInvariants(host_state:HostState, env:HostEnvironment)
   reads *
 predicate ConcreteConfigurationInvariants(config:ConcreteConfiguration)
 
+function ResolveCommandLine(args:seq<seq<uint16>>) : (args':seq<seq<uint16>>)
+  ensures |args'| >= |args|
 function ParseCommandLineConfiguration(args:seq<seq<uint16>>) : (ConcreteConfiguration, set<EndPoint>, set<EndPoint>)
 function ParseCommandLineId(ip:seq<uint16>, port:seq<uint16>) : EndPoint
 
@@ -42,13 +44,13 @@ method HostInitImpl(ghost env:HostEnvironment) returns (
   ensures  ok ==> |env.constants.CommandLineArgs()| >= 2
   ensures  ok ==> HostStateInvariants(host_state, env)
   ensures  ok ==> ConcreteConfigurationInvariants(config)
-  ensures  ok ==> var args := env.constants.CommandLineArgs();
+  ensures  ok ==> var args := ResolveCommandLine(env.constants.CommandLineArgs());
                   var (parsed_config, parsed_servers, parsed_clients) := ParseCommandLineConfiguration(args[0..|args|-2]);
                   && config == parsed_config
                   && servers == parsed_servers
                   && clients == parsed_clients
                   && ConcreteConfigInit(parsed_config, parsed_servers, parsed_clients);
-  ensures  ok ==> var args := env.constants.CommandLineArgs();
+  ensures  ok ==> var args := ResolveCommandLine(env.constants.CommandLineArgs());
                   && id == ParseCommandLineId(args[|args|-2], args[|args|-1])
                   && HostInit(host_state, config, id);
 

--- a/ironfleet/src/Dafny/Distributed/Common/Native/Io.s.dfy
+++ b/ironfleet/src/Dafny/Distributed/Common/Native/Io.s.dfy
@@ -122,6 +122,8 @@ class IPEndPoint
     modifies env.ok
     ensures  env.ok.ok() == ok
     ensures  ok ==> fresh(ep) && ep.env == env && ep.Address() == ipAddress[..] && ep.Port() == port
+
+  static function method{:axiom} DnsResolve(name:seq<uint16>):(resolved_name:seq<uint16>)
 }
 
 function MaxPacketSize() : int { 65507 }

--- a/ironfleet/src/Dafny/Distributed/Impl/LiveSHT/CmdLineParser.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Impl/LiveSHT/CmdLineParser.i.dfy
@@ -39,7 +39,7 @@ function sht_cmd_line_parsing(env:HostEnvironment) : (ConstantsState, EndPoint)
     reads env;
     reads env.constants;
 {
-    var args := env.constants.CommandLineArgs();
+    var args := resolve_cmd_line_args(env.constants.CommandLineArgs());
     if |args| < 2 then
         (ConstantsStateNull(), EndPointNull()) 
     else
@@ -99,16 +99,20 @@ method parse_cmd_line(ghost env:HostEnvironment) returns (ok:bool, config:Consta
 {
     ok := false;
     var num_args := HostConstants.NumCommandLineArgs(env);
-    if num_args < 4 || num_args % 2 != 1 {
+    var args := collect_cmd_line_args(env);
+    assert args == env.constants.CommandLineArgs();
+
+    args := resolve_cmd_line_args(args);
+
+    if |args| < 4 || |args| % 2 != 1 {
         print "Incorrect number of command line arguments.\n";
-        print "Expected: ./Main.exe [IP port]+ [IP port]\n";
+        print "Expected: ./Main.exe [name:port]+ [name:port]\n";
+        print "      or: ./Main.exe [IP port]+ [IP port]\n";
         print "  where the final argument is one of the IP-port pairs provided earlier \n";
         print "Note that the first IP-port pair indicates the root identity\n";
         return;
     }
 
-    var args := collect_cmd_line_args(env);
-    assert args == env.constants.CommandLineArgs();
     var tuple1 := parse_end_points(args[1..|args|-2]);
     ok := tuple1.0;
     var endpoints := tuple1.1;

--- a/ironfleet/src/Dafny/Distributed/Impl/LiveSHT/Host.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Impl/LiveSHT/Host.i.dfy
@@ -13,13 +13,14 @@ module Host_i refines Host_s {
     import opened LiveSHT__SchedulerImpl_i
     import opened LiveSHT__UdpSHT_i
     import opened LiveSHT__Unsendable_i
+    import opened CmdLineParser_i
     import opened ShtCmdLineParser_i 
     export Spec
         provides Native__Io_s, Environment_s, Native__NativeTypes_s
         provides HostState
         provides ConcreteConfiguration
         provides HostInit, HostNext, ConcreteConfigInit, HostStateInvariants, ConcreteConfigurationInvariants
-        provides ParseCommandLineConfiguration, ParseCommandLineId, ArbitraryObject
+        provides ResolveCommandLine, ParseCommandLineConfiguration, ParseCommandLineId, ArbitraryObject
         provides HostInitImpl, HostNextImpl
     export All reveals *
 
@@ -72,6 +73,11 @@ module Host_i refines Host_s {
      && (forall e :: e in clients ==> EndPointIsAbstractable(e))
     }
 
+    function ResolveCommandLine(args:seq<seq<uint16>>) : seq<seq<uint16>>
+    {
+        resolve_cmd_line_args(args)
+    }
+
     function ParseCommandLineConfiguration(args:seq<seq<uint16>>) : (ConcreteConfiguration, set<EndPoint>, set<EndPoint>)
     {
         var sht_config := sht_config_parsing(args);
@@ -109,7 +115,7 @@ module Host_i refines Host_s {
         servers := set e | e in config.hostIds;
         clients := {};
         assert env.constants == old(env.constants);
-        ghost var args := env.constants.CommandLineArgs();
+        ghost var args := resolve_cmd_line_args(env.constants.CommandLineArgs());
         ghost var tuple := ParseCommandLineConfiguration(args[0..|args|-2]);
         ghost var parsed_config, parsed_servers, parsed_clients := tuple.0, tuple.1, tuple.2;
         //assert config.config == parsed_config.config;

--- a/ironfleet/src/Dafny/Distributed/Impl/Lock/CmdLineParser.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Impl/Lock/CmdLineParser.i.dfy
@@ -33,7 +33,7 @@ function lock_cmd_line_parsing(env:HostEnvironment) : (seq<EndPoint>, EndPoint)
     reads env;
     reads env.constants
 {
-    var args := env.constants.CommandLineArgs();
+    var args := resolve_cmd_line_args(env.constants.CommandLineArgs());
     if |args| < 2 then
         ([], EndPointNull()) 
     else
@@ -90,15 +90,19 @@ method ParseCmdLine(ghost env:HostEnvironment) returns (ok:bool, host_ids:seq<En
 {
     ok := false;
     var num_args := HostConstants.NumCommandLineArgs(env);
-    if num_args < 4 || num_args % 2 != 1 {
+    var args := collect_cmd_line_args(env);
+    assert args == env.constants.CommandLineArgs();
+
+    args := resolve_cmd_line_args(args);
+
+    if |args| < 4 || |args| % 2 != 1 {
         print "Incorrect number of command line arguments.\n";
-        print "Expected: ./Main.exe [IP port]+ [IP port]\n";
+        print "Expected: ./Main.exe [name:port]+ [name:port]\n";
+        print "      or: ./Main.exe [IP port]+ [IP port]\n";
         print "  where the final argument is one of the two IP-port pairs provided earlier \n";
         return;
     }
 
-    var args := collect_cmd_line_args(env);
-    assert args == env.constants.CommandLineArgs();
     var tuple1 := parse_end_points(args[1..|args|-2]);
     ok := tuple1.0;
     var endpoints := tuple1.1;

--- a/ironfleet/src/Dafny/Distributed/Impl/Lock/Host.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Impl/Lock/Host.i.dfy
@@ -7,6 +7,7 @@ module Host_i refines Host_s {
     import opened Collections__Sets_i
     import opened Protocol_Node_i
     import opened NodeImpl_i
+    import opened CmdLineParser_i
     import opened LockCmdLineParser_i
     import opened Types_i
     import opened Impl_Node_i
@@ -16,7 +17,7 @@ module Host_i refines Host_s {
         provides HostState
         provides ConcreteConfiguration
         provides HostInit, HostNext, ConcreteConfigInit, HostStateInvariants, ConcreteConfigurationInvariants
-        provides ParseCommandLineConfiguration, ParseCommandLineId, ArbitraryObject
+        provides ResolveCommandLine, ParseCommandLineConfiguration, ParseCommandLineId, ArbitraryObject
         provides HostInitImpl, HostNextImpl
     export All reveals *
 
@@ -57,6 +58,11 @@ module Host_i refines Host_s {
     {
         ValidConfig(config)
      && MapSeqToSet(config, x=>x) == servers
+    }
+
+    function ResolveCommandLine(args:seq<seq<uint16>>) : seq<seq<uint16>>
+    {
+        resolve_cmd_line_args(args)
     }
 
     function ParseCommandLineConfiguration(args:seq<seq<uint16>>) : (ConcreteConfiguration, set<EndPoint>, set<EndPoint>)

--- a/ironfleet/src/Dafny/Distributed/Impl/RSL/Host.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Impl/RSL/Host.i.dfy
@@ -17,6 +17,7 @@ import opened LiveRSL__ReplicaImplClass_i
 import opened LiveRSL__ReplicaImplMain_i
 import opened LiveRSL__UdpRSL_i
 import opened LiveRSL__Unsendable_i
+import opened CmdLineParser_i
 import opened PaxosCmdLineParser_i 
 import opened Collections__Sets_i
 import opened Common__NodeIdentity_i
@@ -63,6 +64,11 @@ predicate ConcreteConfigInit(config:ConcreteConfiguration, servers:set<EndPoint>
   && MapSeqToSet(config.config.replica_ids, x=>x) == servers
   && (forall e :: e in servers ==> EndPointIsAbstractable(e))
   && (forall e :: e in clients ==> EndPointIsAbstractable(e))
+}
+
+function ResolveCommandLine(args:seq<seq<uint16>>) : seq<seq<uint16>>
+{
+  resolve_cmd_line_args(args)
 }
 
 function ParseCommandLineConfiguration(args:seq<seq<uint16>>) : (ConcreteConfiguration, set<EndPoint>, set<EndPoint>)
@@ -112,7 +118,7 @@ method {:timeLimitMultiplier 4} HostInitImpl(ghost env:HostEnvironment) returns 
   servers := set e | e in constants.all.config.replica_ids;
   clients := {};
   assert env.constants == old(env.constants);
-  ghost var args := env.constants.CommandLineArgs();
+  ghost var args := resolve_cmd_line_args(env.constants.CommandLineArgs());
   ghost var tuple := ParseCommandLineConfiguration(args[0..|args|-2]);
   ghost var parsed_config, parsed_servers, parsed_clients := tuple.0, tuple.1, tuple.2;
   assert config.config == parsed_config.config;

--- a/ironfleet/src/Dafny/Distributed/Impl/SHT/Delegations.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Impl/SHT/Delegations.i.dfy
@@ -500,12 +500,12 @@ lemma {:timeLimitMultiplier 16} UpdateCDelegationMap_RHS_Helper(m:CDelegationMap
     assert KeyRangeContains(cr, KeyPlus(k));
     assert m'.lows == m.lows[..new_index] + [Mapping(newkr.klo, id)] + [Mapping(newkr.khi, m.lows[right_index].id)] + m.lows[right_index+1..];
 
-    assert {:split_here} true;
+//    assert {:split_here} true;
 
     assert |m.lows[..new_index]| == new_index == new_index;
     assert |m.lows[..new_index] + [Mapping(newkr.klo, id)] + [Mapping(newkr.khi, m.lows[right_index].id)]| == new_index + 2;
     if |m.lows[right_index+1..]| > k_index as int - new_index - 2 {
-        assert {:split_here} true;
+//        assert {:split_here} true;
         SequenceIndexingHelper(m.lows[..new_index], [Mapping(newkr.klo, id)], [Mapping(newkr.khi, m.lows[right_index].id)], m.lows[right_index+1..], m'.lows, k_index);
         assert m'.lows[k_index] == m.lows[right_index+1..][k_index-new_index - 2];
     } else {

--- a/ironfleet/src/IronfleetShell/Program.cs
+++ b/ironfleet/src/IronfleetShell/Program.cs
@@ -9,7 +9,7 @@ namespace IronfleetShell
     using MathNet.Numerics.Distributions;
 
 
-  class Program
+    class Program
     {
         static void Main(string[] args)
         {
@@ -18,6 +18,7 @@ namespace IronfleetShell
             Console.WriteLine("IronFleet program started.");
             Console.WriteLine("[[READY]]");
             Main__i_Compile.__default._Main();
+            Console.WriteLine("[[EXIT]]");
         }
     }
 }


### PR DESCRIPTION
Replace

```
  dotnet src/Dafny/Distributed/Services/RSL/build/IronfleetShell.dll 127.0.0.1 4001 127.0.0.1 4002 127.0.0.1 4003 127.0.0.1 4001
  dotnet src/Dafny/Distributed/Services/RSL/build/IronfleetShell.dll 127.0.0.1 4001 127.0.0.1 4002 127.0.0.1 4003 127.0.0.1 4002
  dotnet src/Dafny/Distributed/Services/RSL/build/IronfleetShell.dll 127.0.0.1 4001 127.0.0.1 4002 127.0.0.1 4003 127.0.0.1 4003
```

with

```
  dotnet src/Dafny/Distributed/Services/RSL/build/IronfleetShell.dll localhost:4001 localhost:4002 localhost:4003 localhost:4001
  dotnet src/Dafny/Distributed/Services/RSL/build/IronfleetShell.dll localhost:4001 localhost:4002 localhost:4003 localhost:4002
  dotnet src/Dafny/Distributed/Services/RSL/build/IronfleetShell.dll localhost:4001 localhost:4002 localhost:4003 localhost:4003
```
