### PR TITLE
Secure, deterministic hashing of public keys

### DIFF
--- a/ironfleet/README.md
+++ b/ironfleet/README.md
@@ -255,7 +255,8 @@ Finally, run this client command in yet another window:
   dotnet bin/IronSHTClient.dll certs/MySHT.IronSHT.service.txt nthreads=10 duration=30 workload=g numkeys=1000
 ```
 The client's output will primarily consist of reports of the form `#req
-<thread-ID> <request-number> <time-in-ms>`.
+<thread-ID> <request-number> <time-in-ms>`. This output won't start for
+several seconds since the client has a lot of setup to do.
 
 We haven't implemented crash recovery, so if you restart a server its state will
 be empty.

--- a/ironfleet/src/Dafny/Distributed/Common/Native/IoNative.cs
+++ b/ironfleet/src/Dafny/Distributed/Common/Native/IoNative.cs
@@ -35,7 +35,7 @@ namespace Native____Io__s_Compile {
     internal NetClient(IoScheduler i_scheduler, byte[] publicKey)
     {
       scheduler = i_scheduler;
-      myPublicKeyHash = Dafny.Sequence<byte>.FromArray(IoScheduler.HashPublicKey(publicKey));
+      myPublicKeyHash = Dafny.Sequence<byte>.FromArray(scheduler.HashPublicKey(publicKey));
     }
 
     public static int MaxPublicKeySize { get { return 0xFFFFF; } }
@@ -82,6 +82,11 @@ namespace Native____Io__s_Compile {
     public bool Send(Dafny.ISequence<byte> remote, byte[] buffer)
     {
       return scheduler.SendPacket(remote.Elements, buffer);
+    }
+
+    public byte[] HashPublicKey(byte[] key)
+    {
+      return scheduler.HashPublicKey(key);
     }
   }
   

--- a/ironfleet/src/Dafny/Distributed/Protocol/SHT/RefinementProof/RefinementProof.i.dfy
+++ b/ironfleet/src/Dafny/Distributed/Protocol/SHT/RefinementProof/RefinementProof.i.dfy
@@ -595,7 +595,7 @@ lemma SetPreservesRefinement_ExpandFindHashTable(s:SHT_State, s':SHT_State, id:N
 }
 
 
-lemma SetPreservesRefinement_HostClaims(s:SHT_State, s':SHT_State, id:NodeIdentity, recv:set<Packet>, out:set<Packet>, rpkt:Packet, ko:Key, sm:SingleMessage<Message>, m:Message)
+lemma {:timeLimitMultiplier 2} SetPreservesRefinement_HostClaims(s:SHT_State, s':SHT_State, id:NodeIdentity, recv:set<Packet>, out:set<Packet>, rpkt:Packet, ko:Key, sm:SingleMessage<Message>, m:Message)
     requires HiddenInv(s) && InvBasics(s);
     requires HiddenInv(s') && InvBasics(s');
     requires SHT_Next(s, s');

--- a/ironfleet/src/Dafny/Distributed/Services/RSL/Program.cs
+++ b/ironfleet/src/Dafny/Distributed/Services/RSL/Program.cs
@@ -221,7 +221,7 @@ state.
       var nc = Native____Io__s_Compile.NetClient.Create(privateIdentity, ps.LocalHostNameOrAddress, ps.LocalPort,
                                                         serviceIdentity.Servers, ps.Verbose, serviceIdentity.UseSsl);
       Dafny.ISequence<byte>[] serverPublicKeys =
-        serviceIdentity.Servers.Select(server => Dafny.Sequence<byte>.FromArray(IoScheduler.HashPublicKey(server.PublicKey))).ToArray();
+        serviceIdentity.Servers.Select(server => Dafny.Sequence<byte>.FromArray(nc.HashPublicKey(server.PublicKey))).ToArray();
       var ironArgs = Dafny.Sequence<Dafny.ISequence<byte>>.FromArray(serverPublicKeys);
 
       Profiler.Initialize();

--- a/ironfleet/src/Dafny/Libraries/Math/div.i.dfy
+++ b/ironfleet/src/Dafny/Libraries/Math/div.i.dfy
@@ -318,7 +318,7 @@ lemma {:timeLimitMultiplier 2} lemma_mod_neg_neg(x:int, d:int)
   lemma_mul_auto();
 }
 
-lemma lemma_fundamental_div_mod_converse(x:int, d:int, q:int, r:int)
+lemma {:timeLimitMultiplier 2} lemma_fundamental_div_mod_converse(x:int, d:int, q:int, r:int)
   requires d != 0
   requires 0 <= r < d
   requires x == q * d + r

--- a/ironfleet/src/IronLockServer/Program.cs
+++ b/ironfleet/src/IronLockServer/Program.cs
@@ -69,7 +69,7 @@ Allowed keys:
       var nc = Native____Io__s_Compile.NetClient.Create(privateIdentity, ps.LocalHostNameOrAddress, ps.LocalPort,
                                                         serviceIdentity.Servers, ps.Verbose, serviceIdentity.UseSsl);
       Dafny.ISequence<byte>[] serverPublicKeys =
-        serviceIdentity.Servers.Select(server => Dafny.Sequence<byte>.FromArray(IoScheduler.HashPublicKey(server.PublicKey))).ToArray();
+        serviceIdentity.Servers.Select(server => Dafny.Sequence<byte>.FromArray(nc.HashPublicKey(server.PublicKey))).ToArray();
       var ironArgs = Dafny.Sequence<Dafny.ISequence<byte>>.FromArray(serverPublicKeys);
 
       Profiler.Initialize();

--- a/ironfleet/src/IronRSLClient/RSLClient.cs
+++ b/ironfleet/src/IronRSLClient/RSLClient.cs
@@ -24,11 +24,11 @@ namespace IronRSLClient
                                 serviceIdentity.ServiceType, serviceName);
         throw new Exception("Wrong service type");
       }
-      serverPublicKeys = serviceIdentity.Servers.Select(server => IoScheduler.HashPublicKey(server.PublicKey)).ToArray();
       verbose = i_verbose;
       nextSeqNum = 0;
       primaryServerIndex = 0;
       scheduler = IoScheduler.CreateClient(serviceIdentity.Servers, verbose, serviceIdentity.UseSsl);
+      serverPublicKeys = serviceIdentity.Servers.Select(server => scheduler.HashPublicKey(server.PublicKey)).ToArray();
     }
 
     public byte[] SubmitRequest (byte[] request, int timeBeforeServerSwitchMs = 1000)

--- a/ironfleet/src/IronSHTClient/Client.cs
+++ b/ironfleet/src/IronSHTClient/Client.cs
@@ -578,7 +578,7 @@ namespace IronSHTClient
     private void Send(MessageBase msg, byte[] remote)
     {
       var a = msg.ToBigEndianByteArray();
-      remote = IoScheduler.HashPublicKey(remote);
+      remote = scheduler.HashPublicKey(remote);
       if (!scheduler.SendPacket(remote, a))
       {
         throw new InvalidOperationException("failed to send complete message.");

--- a/ironfleet/src/IronSHTServer/Program.cs
+++ b/ironfleet/src/IronSHTServer/Program.cs
@@ -69,7 +69,7 @@ Allowed keys:
       var nc = Native____Io__s_Compile.NetClient.Create(privateIdentity, ps.LocalHostNameOrAddress, ps.LocalPort,
                                                         serviceIdentity.Servers, ps.Verbose, serviceIdentity.UseSsl);
       Dafny.ISequence<byte>[] serverPublicKeys =
-        serviceIdentity.Servers.Select(server => Dafny.Sequence<byte>.FromArray(IoScheduler.HashPublicKey(server.PublicKey))).ToArray();
+        serviceIdentity.Servers.Select(server => Dafny.Sequence<byte>.FromArray(nc.HashPublicKey(server.PublicKey))).ToArray();
       var ironArgs = Dafny.Sequence<Dafny.ISequence<byte>>.FromArray(serverPublicKeys);
 
       Profiler.Initialize();

--- a/ironfleet/src/TestIoFramework/Program.cs
+++ b/ironfleet/src/TestIoFramework/Program.cs
@@ -39,14 +39,15 @@ namespace TestIoFramework
         int serverIndex = rng.Next(serviceIdentity.Servers.Count);
         PublicIdentity serverIdentity = serviceIdentity.Servers[serverIndex];
         byte[] serverPublicKey = serverIdentity.PublicKey;
+        byte[] serverPublicKeyHash = scheduler.HashPublicKey(serverPublicKey);
 
         int randomNumber = rng.Next(10000);
         string message = string.Format("Hello {0}", randomNumber);
         byte[] messageBytes = Encoding.UTF8.GetBytes(message);
 
-        Console.WriteLine("Sending message {0} to {1}", message, IoScheduler.PublicKeyToString(serverPublicKey));
+        Console.WriteLine("Sending message {0} to {1}", message, IoScheduler.PublicKeyToString(serverPublicKeyHash));
         
-        scheduler.SendPacket(serverPublicKey, messageBytes);
+        scheduler.SendPacket(serverPublicKeyHash, messageBytes);
         Thread.Sleep(1000);
       }
     }

--- a/ironfleet/src/TestIoFramework/Program.cs
+++ b/ironfleet/src/TestIoFramework/Program.cs
@@ -27,6 +27,8 @@ namespace TestIoFramework
 
     public void Run()
     {
+      Console.WriteLine("Starting on {0}",
+                        IoScheduler.PublicKeyToString(IoScheduler.GetCertificatePublicKey(scheduler.MyCert)));
       Thread t = new Thread(this.SenderThread);
       t.Start();
       this.ReceiverThread();
@@ -45,7 +47,8 @@ namespace TestIoFramework
         string message = string.Format("Hello {0}", randomNumber);
         byte[] messageBytes = Encoding.UTF8.GetBytes(message);
 
-        Console.WriteLine("Sending message {0} to {1}", message, IoScheduler.PublicKeyToString(serverPublicKeyHash));
+        Console.WriteLine("Sending message {0} to {1}", message,
+                          scheduler.LookupPublicKeyHashAsString(serverPublicKeyHash));
         
         scheduler.SendPacket(serverPublicKeyHash, messageBytes);
         Thread.Sleep(1000);
@@ -57,9 +60,9 @@ namespace TestIoFramework
       while (true) {
         bool ok;
         bool timedOut;
-        byte[] remote;
+        byte[] remotePublicKeyHash;
         byte[] messageBytes;
-        scheduler.ReceivePacket(0, out ok, out timedOut, out remote, out messageBytes);
+        scheduler.ReceivePacket(0, out ok, out timedOut, out remotePublicKeyHash, out messageBytes);
         if (!ok) {
           Console.WriteLine("Not OK, so terminating receiver thread");
           return;
@@ -69,7 +72,8 @@ namespace TestIoFramework
           continue;
         }
         string message = Encoding.UTF8.GetString(messageBytes);
-        Console.WriteLine("Received message {0} from {1}", message, IoScheduler.PublicKeyToString(remote));
+        Console.WriteLine("Received message {0} from {1}", message,
+                          scheduler.LookupPublicKeyHashAsString(remotePublicKeyHash));
       }
     }
   }


### PR DESCRIPTION
There were two problems with the hashing algorithm used for hashing public keys: (1) It wasn't deterministic, so different processes might do it differently. (2) It wasn't secure, so a malicious actor could generate a key pair whose hash collided with that of a trusted server so it could masquerade as that server. This commit uses SHA-256 to solve both problems.

While I was at it, this commit also fixes a couple of other minor issues: (1) TestIoFramework now works again, since it hadn't been updated to send to public key hashes instead of public keys. (2) A couple of the proofs were a bit unstable, and this commit increases their time limit multipliers.